### PR TITLE
added QueryChat dependent visualizations

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -153,12 +153,12 @@ app_ui = shiny.ui.page_sidebar(
                 shiny.ui.card_header(shiny.ui.output_text("chat_title")),
                 shiny.ui.output_data_frame("chat_table"),
                 shiny.ui.download_button("download_data", "Download"),
-                fill=True,
+                # fill=True,
             ),
-            shiny.ui.card(
-                shiny.ui.card_header("Filtered Data"),
-                shiny.ui.output_data_frame("filtered_data")
-            ),
+            # shiny.ui.card(
+            #     shiny.ui.card_header("Filtered Data"),
+            #     shiny.ui.output_data_frame("filtered_data")
+            # ),
             shiny.ui.layout_columns(
                 shiny.ui.card(
                     shiny.ui.card_header("Workforce Trends"),


### PR DESCRIPTION
Created two (and a half) visualizations based off the plots on the first tab. Included:
- worktrends plot
  - Line plot when QC output data frame includes multiple years
  - bar chart when QC output only includes one year
- revenue plot
  - a stacked bar chart that visualizes the sorted revenues of all companies listed in the QC output

Included a check for QC outputs that have the required columns for visualizations.

addresses #44 - Two output visualizations